### PR TITLE
Workflow now enforces permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dmrAnderson/onboardable/security/code-scanning/1](https://github.com/dmrAnderson/onboardable/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimum permissions required for the workflow to function correctly. Based on the actions used in the workflow (`actions/checkout` and `coverallsapp/github-action`), the workflow likely only requires `contents: read` permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as none of the jobs appear to require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
