### PR TITLE
Drop Ruby 3.2 support from CI build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4', '4.0']
+        ruby: ['3.3', '3.4', '4.0']
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Drop Ruby 3.2 from the CI matrix.
+
 ## 1.6.0
 
 - Add support for Ruby 4.0.


### PR DESCRIPTION
https://endoflife.date/ruby