### PR TITLE
Bump bundler from 4.0.3 to 4.0.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   yard-lint (~> 1.2, >= 1.2.3)
 
 BUNDLED WITH
-  4.0.3
+  4.0.11


### PR DESCRIPTION
[4.0.11](https://rubygems.org/gems/bundler/versions/4.0.11)
[4.0.10](https://rubygems.org/gems/bundler/versions/4.0.10)
[4.0.9](https://rubygems.org/gems/bundler/versions/4.0.9)
[4.0.8](https://rubygems.org/gems/bundler/versions/4.0.8)
[4.0.7](https://rubygems.org/gems/bundler/versions/4.0.7)
[4.0.6](https://rubygems.org/gems/bundler/versions/4.0.6)
[4.0.5](https://rubygems.org/gems/bundler/versions/4.0.5)
[4.0.4](https://rubygems.org/gems/bundler/versions/4.0.4)